### PR TITLE
Reduced texture cap to 16

### DIFF
--- a/addons/Clipmap3D/clipmap_3d.gd
+++ b/addons/Clipmap3D/clipmap_3d.gd
@@ -10,9 +10,11 @@ class_name Clipmap3D extends Node3D
 		compute_data = value
 		_compute_handler.compute_data = compute_data
 
-# TODO: enforce max size of 32 textures
+# TODO: enforce max size of 16 textures
 @export var texture_assets: Array[Clipmap3DTextureAsset]:
 	set(value):
+		if value and value.size() > Clipmap3DTextureHandler.MAX_TEXTURE_COUNT:
+			value.resize(Clipmap3DTextureHandler.MAX_TEXTURE_COUNT)
 		texture_assets = value
 		_texture_handler.texture_assets = texture_assets
 

--- a/addons/Clipmap3D/texture_handler.gd
+++ b/addons/Clipmap3D/texture_handler.gd
@@ -1,7 +1,7 @@
 @tool
 class_name Clipmap3DTextureHandler
 
-const MAX_TEXTURE_COUNT: int = 32
+const MAX_TEXTURE_COUNT: int = 16
 
 var texture_assets: Array[Clipmap3DTextureAsset]:
 	set(value):

--- a/demos/erosion_terrain_demo.tscn
+++ b/demos/erosion_terrain_demo.tscn
@@ -8,7 +8,7 @@
 [ext_resource type="Resource" uid="uid://gmucl8qwvxxo" path="res://demos/assets/textures/cliff/cliff_asset.tres" id="5_vsihy"]
 [ext_resource type="Resource" uid="uid://deandw8b7vm76" path="res://demos/assets/textures/snow/snow_asset.tres" id="6_p1oah"]
 [ext_resource type="Resource" uid="uid://di8rne3ikvw1g" path="res://demos/assets/textures/moss/moss_asset.tres" id="7_r2ioa"]
-[ext_resource type="Shader" uid="uid://bu5ooak2588ih" path="res://demos/shaders/full.gdshader" id="8_vsihy"]
+[ext_resource type="Material" uid="uid://dvqdrhnugsl3r" path="res://demos/shaders/full.tres" id="9_p1oah"]
 [ext_resource type="PackedScene" uid="uid://drr32a4jrntnf" path="res://demos/scenes/player/player.tscn" id="14_ew5cq"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_6b21n"]
@@ -43,34 +43,6 @@ compute_shader = ExtResource("2_p1oah")
 texels_per_vertex = Vector2i(6, 6)
 metadata/_custom_type_script = "uid://d20stuy1e0ig"
 
-[sub_resource type="FastNoiseLite" id="FastNoiseLite_p1oah"]
-noise_type = 5
-frequency = 0.7396
-fractal_type = 0
-
-[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_r2ioa"]
-noise = SubResource("FastNoiseLite_p1oah")
-
-[sub_resource type="ShaderMaterial" id="ShaderMaterial_p1oah"]
-render_priority = 0
-shader = ExtResource("8_vsihy")
-shader_parameter/stochastic_noise = SubResource("NoiseTexture2D_r2ioa")
-shader_parameter/stochastic_blend_bias = 0.21
-shader_parameter/use_mip_lod = true
-shader_parameter/triplanar_sharpness = 29.5250013549375
-shader_parameter/lod_blend_ratio = 0.2
-shader_parameter/_texels_per_vertex = Vector2i(6, 6)
-shader_parameter/_target_transform = Projection(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
-shader_parameter/_albedo_remap = PackedInt32Array(0, 1, 2, 3, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
-shader_parameter/_normal_remap = PackedInt32Array(0, 1, 2, 3, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
-shader_parameter/_uv_scales = PackedVector3Array(0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
-shader_parameter/_albedo_modulates = PackedColorArray(0.65519994, 0.84, 0.66444, 1, 0.88120085, 0.8680145, 0.8416278, 1, 1, 1, 1, 1, 0.90359825, 0.90359825, 0.9035982, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
-shader_parameter/_roughness_offsets = PackedFloat32Array(0.142, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-shader_parameter/_normal_depths = PackedFloat32Array(1, 1, 1, 2.866, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
-shader_parameter/_stochastic_offsets = PackedVector3Array(0, 0, 0, 2.32, 2.41, 0.825, 0.855, 1.6, 1.205, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-shader_parameter/_stochastic_rotations = PackedFloat32Array(0.655, 4.97, 1.035, 0.225, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-shader_parameter/_flags = PackedInt32Array(0, 3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_p1oah"]
 
 [node name="ErosionTerrainDemo" type="Node3D" unique_id=932743419]
@@ -101,17 +73,17 @@ text = "Zoom out to see the terrain.
 Increase view -> settings -> z-far to 16000"
 
 [node name="Clipmap3D" type="Node3D" parent="." unique_id=179599073]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 217.99805, 0.00024414063, -529.1292)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 35.077393, 0.00024414063, 1914.5198)
 script = ExtResource("1_e348m")
 compute_data = SubResource("Resource_p1oah")
 texture_assets = Array[ExtResource("3_4ispy")]([ExtResource("4_ob4lt"), ExtResource("5_vsihy"), ExtResource("6_p1oah"), ExtResource("7_r2ioa")])
 mesh_lod_count = 10
 mesh_tile_size = Vector2i(48, 48)
-material = SubResource("ShaderMaterial_p1oah")
+material = ExtResource("9_p1oah")
 aabb_height = 5000.0
 collision_mesh_radius = Vector2i(6, 6)
 collision_physics_material = SubResource("PhysicsMaterial_p1oah")
 metadata/_custom_type_script = "uid://wudkpxu6xggb"
 
 [node name="Player" parent="." unique_id=917553470 instance=ExtResource("14_ew5cq")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -267.72116, 1588.7144, 217.98123)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 656.7761, 2355.6716, 1695.2573)

--- a/demos/shaders/full.gdshader
+++ b/demos/shaders/full.gdshader
@@ -9,7 +9,7 @@ TODO:
 - Use coarse derivatives to pick mip
 */
 
-#define MAX_TEXTURE_COUNT 32
+#define MAX_TEXTURE_COUNT 16
 #define INV_255 0.003921568627450
 #define ALBEDO_DEFAULT vec4(0.8, 0.8, 0.8, 1.0)
 #define NORMAL_DEFAULT vec4(0.5, 0.5, 1.0, 1.0)
@@ -133,10 +133,10 @@ void vertex() {
 struct Material {
 	vec3 albedo;
 	float roughness;
-	
 	vec3 normal;
 	float normal_depth;
 	float ao;
+	
 	float total_weight;
 };
 
@@ -325,8 +325,8 @@ void fragment() {
 	
 	// Texture weight accumulation from control
 	
-	float weights[32];
-	for (int i = 0; i < 32; i++) weights[i] = 0.0;
+	float weights[MAX_TEXTURE_COUNT];
+	for (int i = 0; i < MAX_TEXTURE_COUNT; i++) weights[i] = 0.0;
 	
 	uvec4 id_0_0 = controls_0 >> uvec4(27u) & uvec4(0x1Fu);
 	uvec4 id_0_1 = controls_0 >> uvec4(22u) & uvec4(0x1Fu);
@@ -366,7 +366,7 @@ void fragment() {
 	
 	int samples = 0;
 	
-	for (uint id = 0u; id < 32u; id++) {
+	for (uint id = 0u; id < uint(MAX_TEXTURE_COUNT); id++) {
 		if (weights[id] > 1e-4) {
 			accumulate_material(mat, id, weights[id], normal);
 			samples += 1;

--- a/demos/shaders/full.tres
+++ b/demos/shaders/full.tres
@@ -1,0 +1,31 @@
+[gd_resource type="ShaderMaterial" format=3 uid="uid://dvqdrhnugsl3r"]
+
+[ext_resource type="Shader" uid="uid://bu5ooak2588ih" path="res://demos/shaders/full.gdshader" id="1_tx34x"]
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_p1oah"]
+noise_type = 5
+frequency = 0.7396
+fractal_type = 0
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_r2ioa"]
+noise = SubResource("FastNoiseLite_p1oah")
+
+[resource]
+render_priority = 0
+shader = ExtResource("1_tx34x")
+shader_parameter/stochastic_noise = SubResource("NoiseTexture2D_r2ioa")
+shader_parameter/stochastic_blend_bias = 0.21
+shader_parameter/use_mip_lod = true
+shader_parameter/triplanar_sharpness = 29.5250013549375
+shader_parameter/lod_blend_ratio = 0.2
+shader_parameter/_texels_per_vertex = Vector2i(6, 6)
+shader_parameter/_target_transform = Projection(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)
+shader_parameter/_albedo_remap = PackedInt32Array(0, 1, 2, 3, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
+shader_parameter/_normal_remap = PackedInt32Array(0, 1, 2, 3, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
+shader_parameter/_uv_scales = PackedVector3Array(0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+shader_parameter/_albedo_modulates = PackedColorArray(0.65519994, 0.84, 0.66444, 1, 0.88120085, 0.8680145, 0.8416278, 1, 1, 1, 1, 1, 0.90359825, 0.90359825, 0.9035982, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+shader_parameter/_roughness_offsets = PackedFloat32Array(0.142, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+shader_parameter/_normal_depths = PackedFloat32Array(1, 1, 1, 2.866, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+shader_parameter/_stochastic_offsets = PackedVector3Array(0, 0, 0, 2.32, 2.41, 0.825, 0.855, 1.6, 1.205, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+shader_parameter/_stochastic_rotations = PackedFloat32Array(0.655, 4.97, 1.035, 0.225, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+shader_parameter/_flags = PackedInt32Array(0, 3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)


### PR DESCRIPTION
Strangely just having 32 textures was causing the opaque pass to become prohibitively expensive.